### PR TITLE
Add Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 coverage/
-lib/
+lib/index.cjs.js
+lib/index.esm.js
 node_modules/
 package-lock.json
 yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib/
 node_modules/
 package-lock.json
 yarn.lock
+.idea

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+/**
+ * React-Shielded Shielded site component.
+ * Usage: <Shielded />
+ */
+export default class Shielded extends React.Component<{}> {}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Add the Women's Refuge Shielded Site button to your React website",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
-  "types": "types/index.d.ts",
+  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "react-shielded",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Add the Women's Refuge Shielded Site button to your React website",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
+  "types": "types/index.d.ts",
   "files": [
     "lib"
   ],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,0 @@
-import * as React from 'react';
-
-export default class ReactShielded extends React.Component<{}> {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,3 @@
+import * as React from 'react';
+
+export default class ReactShielded extends React.Component<{}> {}


### PR DESCRIPTION
We use this at work and I noticed it didn't have a type for the component so I thought I would contribute one, hope that's ok.

Add Typescript type declarations to react-shielded.

As `/lib` is the module dir and the types should also be there, so I had to update the `.gitignore` to explude the built files instead of the whole dir.

You can test it in a React TS project using my demo package: https://www.npmjs.com/package/@bosh-code/react-shielded

Open to your suggestions for the comment in the `index.d.ts` file.

Thanks